### PR TITLE
Fix Better Auth Next.js import

### DIFF
--- a/app/api/auth/[...better-auth]/route.ts
+++ b/app/api/auth/[...better-auth]/route.ts
@@ -1,5 +1,8 @@
 import { auth } from '@/lib/auth';
-import { toNextJsHandler } from 'better-auth/nextjs';
+// Import the official Next.js integration from Better Auth.
+// Earlier versions exported this helper under `better-auth/nextjs`, but
+// the current package exposes it as `better-auth/next-js`.
+import { toNextJsHandler } from 'better-auth/next-js';
 
 const { GET, POST } = toNextJsHandler(auth);
 


### PR DESCRIPTION
## Summary
- fix the import path for the Better Auth Next.js integration

## Testing
- `npm run build` *(fails: Failed to fetch Geist fonts)*
- `npx tsc --noEmit` *(fails: several type errors)*

------
https://chatgpt.com/codex/tasks/task_b_688a601217a0832cb219df7aa0010ea8